### PR TITLE
Don't throw an error when the spell source is unknown by Petopia

### DIFF
--- a/GFW_HuntersHelper/HuntersHelper.lua
+++ b/GFW_HuntersHelper/HuntersHelper.lua
@@ -794,7 +794,8 @@ function FHH_SpellHasLearnableBeasts(spellIcon, spellRank)
 	elseif source == nil then
 		return false
 	else
-		error('Unknown source '..source)
+		GFWUtils.Print('Unknown source '..source .. ', Icon: ' .. spellIcon .. ', Rank: ' .. spellRank)
+		-- error('Unknown source '..source)
 	end
 end
 


### PR DESCRIPTION
Don't throw an error when the spell source is unknown by Petopia